### PR TITLE
GNUMakefile: Update error message

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -82,7 +82,7 @@ gencheck:
 	@markdown-table-formatter README-generated.md
 	@echo "==> Comparing generated code to committed code..."
 	@diff -q README.md README-generated.md || \
-    		(echo; echo "Unexpected difference in generated document. Run 'make generate' to update the generated document and commit."; exit 1)
+    		(echo; echo "Unexpected difference in generated document. Run 'make pre-commit' to update the generated document and commit."; exit 1)
 
 test: fmtcheck
 	@TEST=$(TEST) ./scripts/run-gradually-deprecated.sh


### PR DESCRIPTION



This is confusing because the CI error tells the user to run `make generate`.

![Screenshot 2022-09-05 at 15 29 07](https://user-images.githubusercontent.com/789701/188461417-32f05490-74c0-4d0f-ae5d-8bc91957bff8.png)


However in the documentation we ask to run `make pre-commit`

![Screenshot 2022-09-05 at 15 30 22](https://user-images.githubusercontent.com/789701/188461437-b1daefc9-7177-4527-8b0b-a9b2d5f1ef22.png)

I believe writing `make pre-commit` in the error message gives a better indication of what step was missed in the documentation.
