### PR TITLE
Ignore parsing error when running terrafmtcheck

### DIFF
--- a/scripts/terrafmt-check.sh
+++ b/scripts/terrafmt-check.sh
@@ -3,7 +3,11 @@ echo "==> Checking documentation terraform blocks are formatted..."
 files=$(find . -type f -name "*.md" -o -name "*.go" | grep -v -e ".github" -e "-terraform" -e "vendor" -e ".terraform")
 error=false
 for f in $files; do
-  terrafmt diff -c -q "$f" || error=true
+  terrafmt diff -c -q "$f"
+  retValue=$?
+  if [ $retValue -ne 0 ] && [ $retValue -ne 2 ]; then
+      error=true
+  fi
 done
 if ${error}; then
   echo "------------------------------------------------"


### PR DESCRIPTION
This pull request determine the return code from terrafmt, according to the [document](https://github.com/katbyte/terrafmt#exit-codes):

>If a Terraform parsing error is encountered in a block, the exit code is `2`.

>If the command `diff` with the `--check` flag enabled encounters a formatting difference, it will return `4`. If a file contains both blocks with parsing errors and a formatting difference, it will combine the exit codes to return `6`. These codes can be tested using bitwise checks.

>Otherwise, `terrafmt` will return `1` on an error.

So we just keep running if return code is `0` or `2`, which `2` means only parsing errors were met.

This pr should fix #9.