### PR TITLE
Add support for customized terraform-docs config

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -69,19 +69,10 @@ depscheck:
 	@sh "$(CURDIR)/scripts/deps-check.sh"
 
 generate:
-	@echo "--> Generating doc"
-	@rm -f .terraform.lock.hcl
-	@terraform-docs markdown table --output-file README.md --output-mode inject ./
-	@markdown-table-formatter README.md
+	@sh "$(CURDIR)/scripts/generate.sh"
 
 gencheck:
-	@echo "==> Generating..."
-	@cp README.md README-generated.md
-	@terraform-docs markdown table --output-file README-generated.md --output-mode inject ./
-	@markdown-table-formatter README-generated.md
-	@echo "==> Comparing generated code to committed code..."
-	@diff -q README.md README-generated.md || \
-    		(echo; echo "Unexpected difference in generated document. Run 'make pre-commit' to update the generated document and commit."; exit 1)
+	@sh "$(CURDIR)/scripts/gencheck.sh"
 
 test: fmtcheck
 	@TEST=$(TEST) ./scripts/run-gradually-deprecated.sh

--- a/scripts/gencheck.sh
+++ b/scripts/gencheck.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo "==> Generating..."
+cp README.md README-generated.md
+
+if [ -f ".terraform-docs.yml" ]; then
+	terraform-docs -c .terraform-docs.yml --output-file README-generated.md ./
+else
+	terraform-docs markdown table --output-file README-generated.md --output-mode inject ./
+fi
+
+markdown-table-formatter README-generated.md
+echo "==> Comparing generated code to committed code..."
+diff -q README.md README-generated.md || \
+    		(echo; echo "Unexpected difference in generated document. Run 'make pre-commit' to update the generated document and commit."; exit 1)

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "--> Generating doc"
+rm -f .terraform.lock.hcl
+
+if [ -f ".terraform-docs.yml" ]; then
+	terraform-docs -c .terraform-docs.yml --output-file README.md ./
+else
+	terraform-docs markdown table --output-file README.md --output-mode inject ./
+fi
+
+markdown-table-formatter README.md


### PR DESCRIPTION
This pull request added support for customized terraform-docs config file and solved #8 . We could put a `.terraform-docs.yml` file in module's root folder and scaffold would use this config file to generate and compare `README.md` file.