### PR TITLE
Update Dockerfile: adding `less`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV GOPATH=/usr/local/go
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 COPY --from=build /go/bin /usr/local/go/bin
 COPY .terraformrc /root/.terraformrc
-RUN yum update -y && yum install -y yum ca-certificates zip unzip jq nodejs python3-pip make git diffutils build-essential openssh-server && \
+RUN yum update -y && yum install -y yum ca-certificates zip unzip jq nodejs python3-pip make git less diffutils build-essential openssh-server && \
     wget -q https://go.dev/dl/go${GOLANG_IMAGE_TAG}.linux-${TARGETARCH}.tar.gz && \
     tar -C /root -xzf go*.linux-${TARGETARCH}.tar.gz && \
     rm go${GOLANG_IMAGE_TAG}.linux-${TARGETARCH}.tar.gz && \


### PR DESCRIPTION
Adding `less`. When running this image in GitHub codespaces in [terraform-azurerm-aks](https://github.com/Azure/terraform-azurerm-aks) it is now not possible to type `git diff` the command fails because `less` is missing

```
root [ /workspaces/terraform-azurerm-aks ]# git diff
error: cannot run less: No such file or directory
```

To fix the problem now I have to do `yum install less`