### PR TITLE
bug: remove terrafmt for linted docs

### DIFF
--- a/avm_scripts/terrafmt-check.sh
+++ b/avm_scripts/terrafmt-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "==> Checking documentation terraform blocks are formatted..."
-files=$(find . -type f -name "*.md" -o -name "*.go" | grep -v -e ".github" -e "-terraform" -e "vendor" -e ".terraform")
+files=$(find . -type f -name "*.md" -o -name "*.go" | grep -v -e ".github" -e "-terraform" -e "vendor" -e ".terraform" -e "README.md")
 error=false
 for f in $files; do
   terrafmt diff -c -q "$f"

--- a/avm_scripts/terrafmt.sh
+++ b/avm_scripts/terrafmt.sh
@@ -1,6 +1,6 @@
 echo "==> Fixing test and document terraform blocks code with terrafmt..."
 
-files=$(find . -type f -name "*.md" -o -name "*.go" | grep -v -e ".github" -e "-terraform" -e "vendor" -e ".terraform")
+files=$(find . -type f -name "*.md" -o -name "*.go" | grep -v -e ".github" -e "-terraform" -e "vendor" -e ".terraform" -e "README.md")
 for f in $files; do
   terrafmt fmt -f "$f"
   retValue=$?


### PR DESCRIPTION
This resolves an issue where terrafmt is run against the generated README.md files in AVM modules. These docs include terraform blocks for complex variable types that fail terrafmt checking.