### PR TITLE
use hclmerge to merge a new tflint config file when there is override hcl config

### DIFF
--- a/avm_scripts_canary/run-tflint.sh
+++ b/avm_scripts_canary/run-tflint.sh
@@ -2,23 +2,28 @@
 
 set_tflint_config() {
   local env_var=$1
-  local alt_file=$2
+  local override_file=$2
   local default_url=$3
   local download_file=$4
+  local merged_file=$5
 
-  if [ -z "${!env_var}" ]; then
-    if [ -f "$alt_file" ]; then
-      export $env_var="$alt_file"
-    else
-      curl -H 'Cache-Control: no-cache, no-store' -sSL "$default_url" -o "$download_file"
-      export $env_var="$download_file"
-    fi
+  # Always download the file from GitHub
+  curl -H 'Cache-Control: no-cache, no-store' -sSL "$default_url" -o "$download_file"
+
+  # Check if the override file exists
+  if [ -f "$override_file" ]; then
+    # If it does, merge the override file and the downloaded file
+    hclmerge -1 "$override_file" -2 "$download_file" -d "$merged_file"
+    # Set the environment variable to the path of the merged file
+    export $env_var="$merged_file"
+  else
+    # If it doesn't, set the environment variable to the path of the downloaded file
+    export $env_var="$download_file"
   fi
 }
 
-set_tflint_config "TFLINT_CONFIG" ".tflint_alt.hcl" "https://raw.githubusercontent.com/Azure/tfmod-scaffold/main/avm.tflint.hcl" "avm.tflint.hcl"
-set_tflint_config "TFLINT_EXAMPLE_CONFIG" ".tflint_example_alt.hcl" "https://raw.githubusercontent.com/Azure/tfmod-scaffold/main/avm.tflint_example.hcl" "avm.tflint_example.hcl"
-
+set_tflint_config "TFLINT_CONFIG" "avm.tflint.override.hcl" "https://raw.githubusercontent.com/Azure/tfmod-scaffold/main/avm.tflint.hcl" "avm.tflint.hcl" "avm.tflint.merged.hcl"
+set_tflint_config "TFLINT_EXAMPLE_CONFIG" "avm.tflint_example.override.hcl" "https://raw.githubusercontent.com/Azure/tfmod-scaffold/main/avm.tflint_example.hcl" "avm.tflint_example.hcl" "avm.tflint_example.merged.hcl"
 
 echo "==> Checking that code complies with tflint requirements..."
 tflint --init --config=$TFLINT_CONFIG


### PR DESCRIPTION
In the past we'll use `.tflint_alt.hcl` instead of downloaded `avm.tflint.hcl`, so the repo's owner could customize their own tflint config. But once we've upgraded the `avm.tflint.hcl` in the center repo, we might need upgrade all `.tflint_alt.hcl` files to adapt the new config, and that could be very difficult.

In this pr I use [`hclmerge`](https://github.com/lonegunmanb/hclmerge) to ease the pain. It could merge two hcl files like [Terraform override file](https://developer.hashicorp.com/terraform/language/files/override), so when the repo owners want to customize a config, they don't need to maintain a complete `.tflint_alt.hcl` file anymore, instead, they could create a `avm.tflint.override.hcl` or `avm.tflint_example.override.hcl` file, contains the parts they'd like to patch on the centralized version config file.