### PR TITLE
feat: add terraform test script

### DIFF
--- a/avm_scripts/run-tftest.sh
+++ b/avm_scripts/run-tftest.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+echo "!!! WARNING !!!"
+echo "Due to limitations in az cli's implementation on Windows vs Linux,"
+echo "Terraform tests that require Azure authorization will not work."
+echo "Please use Windows Subsystem for Linux (WSL) to run tests."
+echo "!!! WARNING !!!"
+echo
+
+run_tests () {
+  local dir=$1
+  echo "==> Running tests in $dir"
+  pushd $dir
+  if [ ! -d tests ]; then
+    echo "===> No tests directory found in $dir"
+    popd
+    return 0
+  fi
+  terraform init
+  terraform test
+  popd
+}
+
+run_tests .
+
+echo "==> Running tests in submodules..."
+if [ ! -d modules ]; then
+  echo "==> No modules directory found - exiting"
+  exit 0
+fi
+cd modules
+subfolders=$(find ./ -maxdepth 1 -mindepth 1 -type d)
+for d in $subfolders; do
+  generate_docs $d
+done
+cd ..

--- a/avm_scripts/run-tftest.sh
+++ b/avm_scripts/run-tftest.sh
@@ -32,6 +32,6 @@ fi
 cd modules
 subfolders=$(find ./ -maxdepth 1 -mindepth 1 -type d)
 for d in $subfolders; do
-  generate_docs $d
+  run_tests $d
 done
 cd ..

--- a/avmmakefile
+++ b/avmmakefile
@@ -29,6 +29,9 @@ tfvalidatecheck:
 terrafmtcheck:
 	curl -H 'Cache-Control: no-cache, no-store' -sSL "$(REMOTE_SCRIPT)/terrafmt-check.sh" | bash
 
+terraform-test:
+	curl -H 'Cache-Control: no-cache, no-store' -sSL "$(REMOTE_SCRIPT)/run-tftest.sh" | bash
+
 gofmtcheck:
 	curl -H 'Cache-Control: no-cache, no-store' -sSL "$(REMOTE_SCRIPT)/gofmtcheck.sh" | bash
 	curl -H 'Cache-Control: no-cache, no-store' -sSL "$(REMOTE_SCRIPT)/fumptcheck.sh" | bash
@@ -86,4 +89,4 @@ clean:
 clean2:
 	curl -H 'Cache-Control: no-cache, no-store' -sSL "$(REMOTE_SCRIPT)/clean.sh" | bash
 
-.PHONY: clean clean2 docs docscheck fmt gofmt fumpt gosec tffmtcheck tfvalidatecheck terrafmtcheck gofmtcheck golint tflint lint checkovcheck checkovplancheck fmtcheck pr-check unit-test e2e-test version-upgrade-test terrafmt pre-commit depsensure yor-tag autofix tools
+.PHONY: clean clean2 docs docscheck fmt gofmt fumpt gosec tffmtcheck tfvalidatecheck terrafmtcheck terraform-test gofmtcheck golint tflint lint checkovcheck checkovplancheck fmtcheck pr-check unit-test e2e-test version-upgrade-test terrafmt pre-commit depsensure yor-tag autofix tools


### PR DESCRIPTION
Adds terraform test script to be integrated into repo tests and available to WSL/MacOS/Linux users to run locally.

Will modify the `avm` script to mount the `$HOME/.azure` dir into the container to allow tests to work when needing to talk to Azure.

This doesn't work on Windows natively, hence warning