### PR TITLE
bump default tflint-ruleset-avm version

### DIFF
--- a/avm.tflint.hcl
+++ b/avm.tflint.hcl
@@ -6,7 +6,7 @@ plugin "terraform" {
 
 plugin "avm" {
   enabled     = true
-  version     = "0.11.1"
+  version     = "0.11.5"
   source      = "github.com/Azure/tflint-ruleset-avm"
   signing_key = <<-KEY
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/avm.tflint_example.hcl
+++ b/avm.tflint_example.hcl
@@ -6,7 +6,7 @@ plugin "terraform" {
 
 plugin "avm" {
   enabled     = true
-  version     = "0.11.1"
+  version     = "0.11.5"
   source      = "github.com/Azure/tflint-ruleset-avm"
   signing_key = <<-KEY
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/avm.tflint_module.hcl
+++ b/avm.tflint_module.hcl
@@ -6,7 +6,7 @@ plugin "terraform" {
 
 plugin "avm" {
   enabled     = true
-  version     = "0.11.1"
+  version     = "0.11.5"
   source      = "github.com/Azure/tflint-ruleset-avm"
   signing_key = <<-KEY
 -----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
We need to bump tflint-ruleset-avm version so it could bypass checks on Terraform override files.