### PR TITLE
feat: update terraform linter to v0.10.0

### DIFF
--- a/avm.tflint.hcl
+++ b/avm.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "terraform" {
   enabled = true
-  version = "0.5.0"
+  version = "0.10.0"
   source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }
 

--- a/avm.tflint_example.hcl
+++ b/avm.tflint_example.hcl
@@ -1,6 +1,6 @@
 plugin "terraform" {
   enabled = true
-  version = "0.5.0"
+  version = "0.10.0"
   source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }
 

--- a/avm.tflint_module.hcl
+++ b/avm.tflint_module.hcl
@@ -1,6 +1,6 @@
 plugin "terraform" {
   enabled = true
-  version = "0.5.0"
+  version = "0.10.0"
   source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }
 


### PR DESCRIPTION
Fixes issue where old linter does not understand provider function syntax