### PR TITLE
Fix "bash: line 1: @echo: command not found"

### DIFF
--- a/scripts/tffmt.sh
+++ b/scripts/tffmt.sh
@@ -1,2 +1,2 @@
-@echo "==> Formatting terraform code..."
+echo "==> Formatting terraform code..."
 terraform fmt -recursive


### PR DESCRIPTION
The @ symbol before the echo is wrong here, and causes the following error:

```
% docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform:latest make pre-commit
curl -H 'Cache-Control: no-cache, no-store' -sSL ""https://raw.githubusercontent.com/Azure/tfmod-scaffold/main/scripts"/tffmt.sh" | bash
bash: line 1: @echo: command not found
```

I think it is a cut and paste error from here:
https://github.com/Azure/tfmod-scaffold/blob/aa74630edbe35b2fc46e90ecfa198d0267fcc6b1/avmmakefile#L14

But [in the Makefile syntax the @ symbol is correct](https://www.gnu.org/software/make/manual/html_node/Echoing.html)