### PR TITLE
add `avmsec` ruleset scan in `conftest` action

### DIFF
--- a/avm_scripts/conftest.sh
+++ b/avm_scripts/conftest.sh
@@ -36,10 +36,15 @@ for d in $(find . -maxdepth 1 -mindepth 1 -type d); do
     echo "==> Converting Terraform plan to JSON..."
     terraform show -json tfplan.binary > tfplan.json
 
+    mkdir -p ./policy/default_exceptions
+    curl -sS -o ./policy/default_exceptions/avmsec_exceptions.rego https://raw.githubusercontent.com/Azure/policy-library-avm/refs/heads/main/policy/avmsec/avm_exceptions.rego.bak
+
     if [ -d "exceptions" ]; then
-      conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/Azure-Proactive-Resiliency-Library-v2 -p policy -p exceptions tfplan.json || has_error=true
+      conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/Azure-Proactive-Resiliency-Library-v2 -p policy/arpl -p policy/default_exceptions -p exceptions tfplan.json || has_error=true
+      conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/avmsec -p policy/avmsec -p policy/default_exceptions -p exceptions tfplan.json || has_error=true
     else
-      conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/Azure-Proactive-Resiliency-Library-v2 tfplan.json || has_error=true
+      conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/Azure-Proactive-Resiliency-Library-v2 -p policy/arpl -p policy/default_exceptions tfplan.json || has_error=true
+      conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/avmsec -p policy/avmsec -p policy/default_exceptions tfplan.json || has_error=true
     fi
 
     # run post.sh if it exists

--- a/avm_scripts/conftest.sh
+++ b/avm_scripts/conftest.sh
@@ -40,10 +40,10 @@ for d in $(find . -maxdepth 1 -mindepth 1 -type d); do
     curl -sS -o ./policy/default_exceptions/avmsec_exceptions.rego https://raw.githubusercontent.com/Azure/policy-library-avm/refs/heads/main/policy/avmsec/avm_exceptions.rego.bak
 
     if [ -d "exceptions" ]; then
-      conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/Azure-Proactive-Resiliency-Library-v2 -p policy/arpl -p policy/default_exceptions -p exceptions tfplan.json || has_error=true
+      conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/Azure-Proactive-Resiliency-Library-v2 -p policy/aprl -p policy/default_exceptions -p exceptions tfplan.json || has_error=true
       conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/avmsec -p policy/avmsec -p policy/default_exceptions -p exceptions tfplan.json || has_error=true
     else
-      conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/Azure-Proactive-Resiliency-Library-v2 -p policy/arpl -p policy/default_exceptions tfplan.json || has_error=true
+      conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/Azure-Proactive-Resiliency-Library-v2 -p policy/aprl -p policy/default_exceptions tfplan.json || has_error=true
       conftest test --all-namespaces --update git::https://github.com/Azure/policy-library-avm.git//policy/avmsec -p policy/avmsec -p policy/default_exceptions tfplan.json || has_error=true
     fi
 


### PR DESCRIPTION
This pr added `avmsec` rules check in `conftest` action.

Before check, it would download [https://raw.githubusercontent.com/Azure/policy-library-avm/refs/heads/main/policy/avmsec/avm_exceptions.rego.bak](https://github.com/Azure/policy-library-avm/blob/0a94fe512cb8f5fa8337d9b5702b5fca0237a5da/policy/avmsec/avm_exceptions.rego.bak#L1-L10) and save it as `policy/default_exceptions/avmsec_exceptions.rego` file, ignore all non-high severity rules check.

Now all implemented high severity rules are:

Azure Key Vault Keys does not have expiration date	AVM_SEC_40	HIGH
Azure Linux scale set does not use an SSH key	AVM_SEC_49	HIGH
Azure Microsoft Defender for Cloud is set to Off for Container Registries	AVM_SEC_86	HIGH
Azure Security Center Defender set to Off for Kubernetes	AVM_SEC_85	HIGH
Azure SQL server send alerts to field value is not set	AVM_SEC_26	HIGH
Azure SQL Server threat detection alerts are not enabled for all threat types	AVM_SEC_25	HIGH
Backend of the API management system does not utilize HTTPS	AVM_SEC_215	HIGH
Event Hub Namespace not using TLS 1.2 or greater	AVM_SEC_223	HIGH
Linux VM Without SSH Key	AVM_SEC_178 	HIGH









