### PR TITLE
improve error message when mapotf-precommit-check fail

### DIFF
--- a/avm_scripts/mapotf-precommit-check.sh
+++ b/avm_scripts/mapotf-precommit-check.sh
@@ -3,7 +3,7 @@ set -e
 
 # Ensure git working directory is clean
 if [[ -n $(git status --porcelain) ]]; then
-  echo "Error: Git working directory must be clean before running this check."
+  echo "git status shows uncommitted changes. Please commit or stash them before running this script."
   exit 1
 fi
 


### PR DESCRIPTION
The original error message when user have uncommitted changes is confusing. This pr improve the error message to make it more clear to the user.