### PR TITLE
improve avm image tag

### DIFF
--- a/.github/workflows/new-tag.yaml
+++ b/.github/workflows/new-tag.yaml
@@ -13,10 +13,12 @@ jobs:
         image:
           - name: azterraform
             repo: public/azterraform
+            tag_prefix: ""
             dockerfile: Dockerfile_azterraform
             source_files: "Dockerfile.build Dockerfile.azterraform"
           - name: avm
-            repo: public/avm
+            repo: public/azterraform
+            tag_prefix: "avm-"
             dockerfile: Dockerfile_avm
             source_files: "Dockerfile.build Dockerfile.avm"
     steps:
@@ -67,7 +69,7 @@ jobs:
             linux/amd64
             linux/arm64
           tags: |
-            ${{ secrets.DOCKER_SERVER_URL }}/${{ matrix.image.repo }}:latest
-            ${{ secrets.DOCKER_SERVER_URL }}/${{ matrix.image.repo }}:${{ env.APP_VERSION }}
+            ${{ secrets.DOCKER_SERVER_URL }}/${{ matrix.image.repo }}:${{ matrix.image.tag_prefix }}latest
+            ${{ secrets.DOCKER_SERVER_URL }}/${{ matrix.image.repo }}:${{ matrix.image.tag_prefix }}${{ env.APP_VERSION }}
           build-args: |
             ${{ steps.readenv.outputs.content }}


### PR DESCRIPTION
This pr improves the avm image. Since we'd like to reuse the current mcr onboarding process to save time, we have to push both `azterraform` and `avm` images into the same ACR repo: `public/azterraform`, but with different tags.

This pr introduced a new matrix parameter `tag_prefix`, for the same tag version `v1.2.3`, the image for legacy TFVM and other repos would be `public/azterraform:latest` and `public/azterraform:v1.2.3`, and the image for AVM repos would be `public/azterraform:avm-latest` and `public/azterraform:avm-v1.2.3`.